### PR TITLE
jQuery 3.5.1 compatibility

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,20 +5,19 @@
         <a class="btnstylerev" back-button>{{ ::'Back' | translate }}</a>
         <h2 class="page-header">Python Plugins Manager</h2>
 
-        <page-loading-indicator ng-hide="::$ctrl.plugins"/>
+        <page-loading-indicator ng-hide="::$ctrl.plugins"></page-loading-indicator>
 
         <pp-manager-plugins-table
                 ng-if="::$ctrl.plugins"
                 plugins="$ctrl.plugins"
-                on-update="$ctrl.refreshPlugins()"
-        />
+                on-update="$ctrl.refreshPlugins()"></pp-manager-plugins-table>
     </div>
 </script>
 
 <script>
     require(['../templates/plugins-manager'], function() {
         angular.element(document).injector().invoke(function($compile) {
-            var $div = angular.element('<pp-manager-plugin />');
+            var $div = angular.element('<pp-manager-plugin></pp-manager-plugin>');
             angular.element('#plugin-view').append($div);
 
             var scope = angular.element($div).scope();


### PR DESCRIPTION
Hello,

In the development branch of Domoticz, in the www component of Domoticz, jQuery has been updated to version 3.5.1. With this update an incompatibility has been found with self-closing html-tags. This causes the Python Plugin Manager page not render properly.

This PR replaces the self-closing tags with an open-tag and a corresponding close-tag in order to fix this plugin in Domoticz.

Please allow this change in your code. :-)