### PR TITLE
Added WLED plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -455,6 +455,14 @@
         "name": "WLANThermo",
         "repository": "https://github.com/galadril/Domoticz-WLANThermo-Plugin"
     },
+    "WLED": {
+        "author": "frustreermeneer",
+        "branch": "master",
+        "description": "WLED",
+        "folder": "wled",
+        "name": "WLED Plugin",
+        "repository": "https://github.com/frustreermeneer/domoticz-wled-plugin"
+    },
     "xiaomi-mi-robot-vacuum": {
         "author": "mrin",
         "branch": "master",


### PR DESCRIPTION
I added my Domoticz plugin that interfaces with WLED.

WLED is a fast and feature-rich implementation of an ESP8266/ESP32 webserver to control NeoPixel LEDs or also SPI based chipsets like the WS2801.