### PR TITLE
FIX : MQTTDiscovery git branch (master is empty)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -121,7 +121,7 @@
     },
     "MQTTDiscovery": {
         "author": "emontnemery",
-        "branch": "master",
+        "branch": "development",
         "description": "MQTT discovery",
         "folder": "MQTTDiscovery",
         "name": "domoticz_mqtt_discovery",


### PR DESCRIPTION
If you check MQTTDiscovery GitHub project page you will notice that plugin live in development branch.