### PR TITLE
Add Domoticz-sync-timer plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -478,5 +478,13 @@
         "folder": "yi-hack",
         "name": "Yi Hack Plugin",
         "repository": "https://github.com/galadril/Domoticz-Yi-Hack-Plugin"
+    },
+	    "Update_timer_Plugin": {
+        "author": "skarab22",
+        "branch": "master",
+        "description": "Synchronize your devices on the corresponding active timer",
+        "folder": "Update_timer",
+        "name": "Update_timer Plugin",
+        "repository": "https://github.com/skarab22/Domoticz-sync-timer"
     }
 }


### PR DESCRIPTION
Add new plugin from [https://github.com/skarab22/Domoticz-sync-timer](https://github.com/skarab22/Domoticz-sync-timer)

This plugin has been developed to synchronize devices state after a restart of Domoticz service or after changing Timer Plan.