### PR TITLE
Add branch selection for plugins

### DIFF
--- a/.github/scripts/validate_plugins.py
+++ b/.github/scripts/validate_plugins.py
@@ -68,32 +68,32 @@ def validate_plugins(file_path):
             broken_urls.append((key, url))
             continue
 
-        # First check if repo URL is reachable (without /tree/branch)
+        # Extract owner, repo, and possible branch from URL
         owner, repo, branch_from_url = extract_owner_repo_branch(url)
         if owner is None or repo is None:
             print(f"Invalid GitHub URL format for plugin '{key}': {url}")
             broken_urls.append((key, url))
             continue
         
-        # Compose repo base URL without branch path for validation
         repo_url = f"https://github.com/{owner}/{repo}"
         if not check_url_exists(repo_url):
             print(f"Broken repository URL: {repo_url}")
             broken_urls.append((key, repo_url))
             continue
         
-        # Determine which branch to check
-        branch_to_check = branch_field if branch_field else branch_from_url
+        # Determine branch to check
+        branch_to_check = branch_field if branch_field is not None else branch_from_url
         if branch_to_check is None:
-            # No branch info, fallback to 'master'
             branch_to_check = 'master'
 
-        # Branch should be a string and not a list/array
+        # Handle branch as array or string
         if isinstance(branch_to_check, list):
-            # Invalid branch format
-            print(f"❌ Invalid branch list for plugin '{key}': {branch_to_check}")
-            invalid_branch_format.append((key, branch_to_check))
-            continue
+            if len(branch_to_check) == 1 and isinstance(branch_to_check[0], str):
+                branch_to_check = branch_to_check[0]
+            else:
+                print(f"❌ Invalid branch list for plugin '{key}': {branch_to_check}")
+                invalid_branch_format.append((key, branch_to_check))
+                continue
         if not isinstance(branch_to_check, str):
             print(f"❌ Invalid branch value for plugin '{key}': {branch_to_check}")
             invalid_branch_format.append((key, branch_to_check))

--- a/.github/scripts/validate_plugins.py
+++ b/.github/scripts/validate_plugins.py
@@ -2,43 +2,85 @@ import json
 import requests
 import sys
 
+def extract_owner_repo(url):
+    try:
+        parts = url.rstrip('/').split('/')
+        return parts[-2], parts[-1]
+    except Exception:
+        return None, None
+
+def check_github_branch_exists(owner, repo, branch):
+    api_url = f"https://api.github.com/repos/{owner}/{repo}/branches/{branch}"
+    try:
+        response = requests.get(api_url, timeout=10)
+        return response.status_code == 200
+    except requests.RequestException:
+        return False
+
 def validate_plugins(file_path):
     try:
         with open(file_path, 'r') as file:
             plugins = json.load(file)
     except (FileNotFoundError, json.JSONDecodeError) as e:
-        print(f"Error reading plugins.json: {e}")
+        print(f"❌ Error reading plugins.json: {e}")
         sys.exit(1)
 
-    valid_urls = []
-    broken_urls = []
+    valid_plugins = []
+    broken_plugins = []
 
     for key, plugin in plugins.items():
-        url = plugin.get('repository')  # Use `.get()` to avoid KeyError
+        url = plugin.get('repository')
+        branches = plugin.get('branch', [])
+
         if not url or not url.startswith(("http://", "https://")):
-            print(f"Invalid or missing URL for plugin {key}: {url}")
-            broken_urls.append((key, url))
+            print(f"❌ Invalid or missing URL for plugin '{key}': {url}")
+            broken_plugins.append((key, url, "Invalid URL"))
             continue
 
+        if not isinstance(branches, list) or not all(isinstance(b, str) for b in branches):
+            print(f"❌ Invalid branch list for plugin '{key}': {branches}")
+            broken_plugins.append((key, url, "Invalid branch format"))
+            continue
+
+        # Check repository accessibility
         try:
-            response = requests.get(url, timeout=10)  # Add timeout
-            if response.status_code == 200:
-                print(f"Valid URL: {url}")
-                valid_urls.append(url)
+            repo_response = requests.get(url, timeout=10)
+            if repo_response.status_code != 200:
+                print(f"❌ Broken repo URL: {url} (HTTP {repo_response.status_code})")
+                broken_plugins.append((key, url, "Repo not reachable"))
+                continue
+        except requests.RequestException as e:
+            print(f"❌ Repo URL exception for {key}: {url} - {e}")
+            broken_plugins.append((key, url, f"Request error: {e}"))
+            continue
+
+        # Check each branch
+        owner, repo = extract_owner_repo(url)
+        if not owner or not repo:
+            print(f"❌ Could not extract owner/repo from URL: {url}")
+            broken_plugins.append((key, url, "Invalid GitHub URL format"))
+            continue
+
+        all_branches_valid = True
+        for branch in branches:
+            if check_github_branch_exists(owner, repo, branch):
+                print(f"✅ Branch '{branch}' exists for plugin '{key}'")
             else:
-                print(f"Broken URL: {url} (HTTP {response.status_code})")
-                broken_urls.append((key, url))
-        except requests.exceptions.RequestException as e:
-            print(f"Broken URL: {url} - Exception: {e}")
-            broken_urls.append((key, url))
+                print(f"❌ Branch '{branch}' does NOT exist for plugin '{key}'")
+                broken_plugins.append((key, f"{url}/tree/{branch}", f"Missing branch: {branch}"))
+                all_branches_valid = False
 
-    # Output summary
-    print("\nValidation Summary:")
-    print(f"Valid URLs: {len(valid_urls)}")
-    print(f"Broken URLs: {len(broken_urls)}")
+        if all_branches_valid:
+            valid_plugins.append(key)
 
-    # Exit with non-zero status code if broken URLs are found
-    if broken_urls:
+    print("\n🔍 Validation Summary:")
+    print(f"✔️  Valid plugins: {len(valid_plugins)}")
+    print(f"❌ Plugins with issues: {len(broken_plugins)}")
+
+    if broken_plugins:
+        print("\n❗ Issues found:")
+        for item in broken_plugins:
+            print(f"  - Plugin: {item[0]} | URL: {item[1]} | Reason: {item[2]}")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/api/commands/install.py
+++ b/api/commands/install.py
@@ -6,22 +6,21 @@ import Domoticz
 class Install(APICommand):
     def execute(self, params):
         if isinstance(params, dict):
-            plugin_key = params.get('plugin')
+            plugin_key = params.get('key')
             branch = params.get('branch')
         else:
             plugin_key = params
             branch = None
 
-        Domoticz.Log(f'Executing install command with plugin_key: {plugin_key}, branch: {branch}')
+        Domoticz.Log(f"Received install request for plugin: {plugin_key}, branch: {branch}")
 
         if plugin_key not in plugins:
-            Domoticz.Error(f'Plugin {plugin_key} not found')
-            self.send_error('Plugin not found')
+            self.send_error(f'Plugin {plugin_key} not found')
             return None
 
         plugin = plugins[plugin_key]
 
         if plugin.install(branch):
-            self.send_response('Plugin has been succesfully installed. Please restart Domoticz to take effect.')
+            self.send_response('Plugin has been successfully installed. Please restart Domoticz to take effect.')
         else:
-            self.send_error('Error occured during plugin installation. Please check Domoticz Log for more details.')
+            self.send_error('Error occurred during plugin installation. Please check Domoticz Log for more details.')

--- a/api/commands/install.py
+++ b/api/commands/install.py
@@ -1,5 +1,6 @@
 from api.api_command import APICommand
 from plugins import plugins
+import Domoticz
 
 
 class Install(APICommand):
@@ -11,7 +12,10 @@ class Install(APICommand):
             plugin_key = params
             branch = None
 
+        Domoticz.Log(f'Executing install command with plugin_key: {plugin_key}, branch: {branch}')
+
         if plugin_key not in plugins:
+            Domoticz.Error(f'Plugin {plugin_key} not found')
             self.send_error('Plugin not found')
             return None
 

--- a/api/commands/install.py
+++ b/api/commands/install.py
@@ -4,13 +4,20 @@ from plugins import plugins
 
 class Install(APICommand):
     def execute(self, params):
-        if params not in plugins:
+        if isinstance(params, dict):
+            plugin_key = params.get('plugin')
+            branch = params.get('branch')
+        else:
+            plugin_key = params
+            branch = None
+
+        if plugin_key not in plugins:
             self.send_error('Plugin not found')
             return None
 
-        plugin = plugins[params]
+        plugin = plugins[plugin_key]
 
-        if (plugin.install()):
+        if plugin.install(branch):
             self.send_response('Plugin has been succesfully installed. Please restart Domoticz to take effect.')
         else:
             self.send_error('Error occured during plugin installation. Please check Domoticz Log for more details.')

--- a/api/commands/list.py
+++ b/api/commands/list.py
@@ -12,7 +12,8 @@ class List(APICommand):
                 'author': plugin.author,
                 'description': plugin.description,
                 'name': plugin.name,
-                'source': plugin.repository + '/tree/' + plugin.branch,
+                'source': plugin.repository + '/tree/' + plugin.branch[0],
+                'branches': plugin.branch,
                 'is_installed': plugin.is_installed(),
                 'is_update_available': plugin.is_update_available(),
             }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -159,6 +159,12 @@ define(['app'], function(app) {
                     { title: 'Description', data: 'description' },
                     { title: 'Author', data: 'author' },
                     {
+                        title: 'Branch',
+                        data: 'branches',
+                        orderable: false,
+                        render: branchesRenderer
+                    },
+                    {
                         title: '',
                         className: 'actions-column',
                         width: '80px',
@@ -171,10 +177,11 @@ define(['app'], function(app) {
 
             table.on('click', '.js-install', function() {
                 var plugin = table.api().row($(this).closest('tr')).data();
+                var selectedBranch = $(this).closest('tr').find('.branch-select').val();
 
                 bootbox.confirm('Are you sure you want to install "' + plugin.name + '" plugin?')
                     .then(function() {
-                        return ppManager.sendRequest('install', plugin.key);
+                        return ppManager.sendRequest('install', { key: plugin.key, branch: selectedBranch });
                     })
                     .then(bootbox.alert, bootbox.alert)
                     .then($ctrl.onUpdate);
@@ -232,6 +239,14 @@ define(['app'], function(app) {
             return isInstalled
                 ? '<img src="../../images/ok.png" title="Installed" width="16" height="16" />'
                 : '<img src="../../images/empty16.png" width="16" height="16" />'
+        }
+
+        function branchesRenderer(branches) {
+            var options = branches.map(function(branch) {
+                return '<option value="' + branch + '">' + branch + '</option>';
+            }).join('');
+
+            return '<select class="branch-select">' + options + '</select>';
         }
 
         function actionsRenderer(data, type, plugin) {

--- a/manager.py
+++ b/manager.py
@@ -71,7 +71,7 @@ class Plugin():
 
         return None
 
-    def install(self):
+    def install(self, branch=None):
         Domoticz.Log("Installing Plugin:" + self.description)
 
         if (self.is_installed()):
@@ -79,7 +79,8 @@ class Plugin():
         
         plugins_folder = os.path.dirname(str(os.getcwd()) + "/plugins/")
         repository = self.repository + ".git"
-        clone_cmd="LANG=en_US /usr/bin/git clone -b " + self.branch + " " + repository + " " + self.folder_name
+        branch = branch or self.branch[0]
+        clone_cmd="LANG=en_US /usr/bin/git clone -b " + branch + " " + repository + " " + self.folder_name
         Domoticz.Debug("Calling: " + clone_cmd)
 
         try:

--- a/plugins.json
+++ b/plugins.json
@@ -1,7 +1,7 @@
 {
     "AAPIPModule": {
         "author": "febalci",
-        "branch": "master",
+        "branch": [["master"]],
         "description": "Crow Runner Alarm",
         "folder": "AAPIPModule",
         "name": "DomoticzCrowAlarm",
@@ -9,7 +9,7 @@
     },
     "AWTRIX3": {
         "author": "galadril",
-        "branch": "master",
+        "branch": [["master"]],
         "description": "AWTRIX3 Smart Clock",
         "folder": "Domoticz-AWTRIX3-Plugin",
         "name": "AWTRIX3",
@@ -17,7 +17,7 @@
     },
     "BatteryLevel": {
         "author": "999LV",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Battery monitoring for Z-Wave nodes",
         "folder": "BatteryLevel",
         "name": "BatteryLevel",
@@ -25,7 +25,7 @@
     },
     "Buienradar": {
         "author": "ffes",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Buienradar.nl (Weather lookup)",
         "folder": "Buienradar",
         "name": "domoticz-buienradar",
@@ -33,7 +33,7 @@
     },
     "ChromecastPlugin": {
         "author": "Tsjippy",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Chromecast plugin for Domoticz",
         "folder": "ChromecastPlugin",
         "name": "ChromecastPlugin",
@@ -41,7 +41,7 @@
 	},
     "CreasolDombusPlugin": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Creasol DomBus RS485 modules (I/Os and sensors)",
         "folder": "CreasolDomBus",
         "name": "CreasolDomBusPlugin",
@@ -49,7 +49,7 @@
     },
     "DDS238": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "DDS238 ZN/S energy meter, single phase, Modbus RTU",
         "folder": "domoticz-dds238",
         "name": "domoticz-dds238",
@@ -57,7 +57,7 @@
     },
     "DTS238": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "DTS238 ZN/S energy meter, three phase, Modbus RTU",
         "folder": "domoticz-dts238",
         "name": "domoticz-dts238",
@@ -65,7 +65,7 @@
     },
     "Denon4306": {
         "author": "dnpwwo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Denon/Marantz Amplifier",
         "folder": "Denon4306",
         "name": "Domoticz-Denon-Plugin",
@@ -73,7 +73,7 @@
     },
     "DysonPureLink": {
         "author": "JanJaapKo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Domoticz plugin to integrate the Dyson PureLink devices",
         "folder": "DysonPureLink",
         "name": "Dyson Pure Link",
@@ -81,7 +81,7 @@
     },
     "E-Flux": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "'E-Flux by Road' back office of your EV Charger",
         "folder": "Domoticz-E-Flux-Plugin",
         "name": "E-Flux",
@@ -89,7 +89,7 @@
     },
     "EmmetiEQ2021": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Emmeti EQ 2021 and EQ 3021 ES hot water heat pumps",
         "folder": "domoticz-emmeti-eq2021",
         "name": "Emmeti hot water heat pump",
@@ -97,7 +97,7 @@
     },
     "EmmetiMirai": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Emmeti Mirai heat pumps management",
         "folder": "domoticz-emmeti-mirai",
         "name": "Emmeti Mirai heat pump",
@@ -105,7 +105,7 @@
     },
     "GC-100": {
         "author": "dnpwwo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Global Cache 100",
         "folder": "GC-100",
         "name": "Domoticz-GlobalCache-Plugin",
@@ -113,7 +113,7 @@
     },
     "GoodWeAPI": {
         "author": "JanJaapKo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Provides information about your GoodWe solar inverter too Domoticz",
         "folder": "domoticz-GoodWeSEMS",
         "name": "GoodWE Solar inverter via SEMS API",
@@ -121,7 +121,7 @@
     },
     "GoveeDiscovery": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Plugin to discover Govee devices on the local network and create/update devices in Domoticz",
         "folder": "Domoticz-Govee-Plugin",
         "name": "Govee Local Api Control",
@@ -129,7 +129,7 @@
     },
     "Hisense-AEH-W4A1": {
         "author": "x-th-unicorn",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Domoticz Python plugin for Hisense AC (AEH-W4A1)",
         "folder": "domoticz-aeh-w4a1",
         "name": "domoticz-aeh-w4a1",
@@ -137,7 +137,7 @@
     },
     "HivePlug": {
         "author": "imcfarla2003",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Hive Plugin",
         "folder": "HivePlug",
         "name": "domoticz-hive",
@@ -145,7 +145,7 @@
     },
     "Homewizard": {
         "author": "rvdvoorde",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Homewizard",
         "folder": "Homewizard",
         "name": "domoticz-homewizard",
@@ -153,7 +153,7 @@
     },
     "HyundaiKia": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Hyundai and Kia connect cars",
         "folder": "domoticz-hyundai-kia",
         "name": "Hyundai and kia connect cars",
@@ -161,7 +161,7 @@
     },
     "IKEA-Tradfri": {
         "author": "moroen",
-        "branch": "master",
+        "branch": ["master"],
         "description": "IKEA Tradfri",
         "folder": "IKEA-Tradfri",
         "name": "IKEA-Tradfri-plugin",
@@ -169,7 +169,7 @@
     },
     "IthoWifi": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Itho Wifi module",
         "folder": "Domoticz-Itho-Wifi-Plugin",
         "name": "Domoticz-Itho-Wifi-Plugin",
@@ -177,7 +177,7 @@
     },
      "Kodi": {
         "author": "dnpwwo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Kodi Media Player Plugin",
         "folder": "Domoticz-Kodi-Plugin",
         "name": "Kodi Players",
@@ -185,7 +185,7 @@
     },
     "Linky": {
         "author": "guillaumezin",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Linky",
         "folder": "Linky",
         "name": "DomoticzLinky",
@@ -201,7 +201,7 @@
     },
     "MeteoAlarmEU": {
         "author": "ycahome",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Meteo Alarm EU RSS Reader",
         "folder": "MeteoAlarmEU",
         "name": "MeteoAlarmEU",
@@ -209,7 +209,7 @@
     },
     "Mi_Flower_mate": {
         "author": "flatsiedatsie",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Xiaomi Mi Flower Mate",
         "folder": "Mi_Flower_mate_plugin",
         "name": "Xiaomi Mi Flower Mate",
@@ -217,7 +217,7 @@
     },
     "MilightESP8266": {
         "author": "mrin",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Support for ESP8266 Milight hub",
         "folder": "espmilighthub-domoticz",
         "name": "ESP8266 Milight Hub",
@@ -225,7 +225,7 @@
     },
     "MoonPhases": {
         "author": "ycahome",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Moon Phases",
         "folder": "MoonPhases",
         "name": "MoonPhases",
@@ -233,7 +233,7 @@
     },
     "NUT_UPS": {
         "author": "999LV",
-        "branch": "master",
+        "branch": ["master"],
         "description": "UPS Monitor python plugin for Domoticz",
         "folder": "NUT_UPS",
         "name": "UPS Monitor",
@@ -241,7 +241,7 @@
     },
     "Onkyo": {
         "author": "jorgh6",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Onkyo AV Receiver",
         "folder": "Onkyo",
         "name": "domoticz-onkyo-plugin",
@@ -249,7 +249,7 @@
     },
     "PZEM-016": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "PZEM-016 PZEM-014 and PZEM-004T energy meters (supports up to 51 meters on the same bus)",
         "folder": "domoticz-pzem-016",
         "name": "PZEM-016 PZEM-014 PZEM-004T energy meters",
@@ -257,7 +257,7 @@
     },
     "Quatt": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Quatt",
         "folder": "Domoticz-Quatt-Plugin",
         "name": "Domoticz-Quatt-Plugin",
@@ -265,7 +265,7 @@
     },
     "RAVEn": {
         "author": "dnpwwo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "RAVEn Zigbee energy monitor",
         "folder": "RAVEn",
         "name": "Domoticz-RAVEn-Plugin",
@@ -273,7 +273,7 @@
     },
     "SNMPreader": {
         "author": "ycahome",
-        "branch": "master",
+        "branch": ["master"],
         "description": "SNMP Reader",
         "folder": "SNMPreader",
         "name": "SNMPreader",
@@ -281,7 +281,7 @@
     },
     "SYSFS-Switches": {
         "author": "flatsiedatsie",
-        "branch": "master",
+        "branch": ["master"],
         "description": "SYSFS-Switches",
         "folder": "SYSFS-Switches",
         "name": "GPIO-SYSFS-Switches",
@@ -289,7 +289,7 @@
     },
     "Shelly_MQTT": {
         "author": "enesbcs",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Shelly MQTT translator",
         "folder": "Shelly_MQTT",
         "name": "Shelly MQTT",
@@ -297,7 +297,7 @@
     },
     "SmogTok": {
         "author": "smogtok",
-        "branch": "master",
+        "branch": ["master"],
         "description": "SmogTok Air Quality monitor",
         "folder": "SmogTok",
         "name": "smogtokdomoticzplug",
@@ -305,7 +305,7 @@
     },
     "solaredge modbus_tcp": {
         "author": "addiejansen",
-        "branch": "master",
+        "branch": ["master"],
         "description": "collect data from SolarEdge power inverters over ModbusTCP.",
         "folder": "domoticz-solaredge-modbustcp-plugin",
         "name": "solaredge modbus-tcp",
@@ -313,7 +313,7 @@
     },
     "Sonos": {
         "author": "gerard33",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Sonos Players",
         "folder": "Sonos",
         "name": "sonos",
@@ -321,7 +321,7 @@
     },
     "Synology SurveillanceStation": {
         "author": "lolautruche",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Synology SurveillanceStation",
         "folder": "Synology SurveillanceStation",
         "name": "SurveillanceStationDomoticz",
@@ -329,7 +329,7 @@
     },
     "TasmotaH801": {
         "author": "stas-demydiuk",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Control H801 LED WiFi Controller with Tasmota firmware via MQTT",
         "folder": "h801-tasmota-plugin",
         "name": "H801 LED WiFi Controller with Tasmota firmware",
@@ -337,7 +337,7 @@
     },
     "Thermostat Weekly Scheduler": {
         "author": "ArtBern",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Manipulate schedule for virtual thermostat on weekly basis. Easy switch for timer plans.",
         "folder": "thermostat-weekly-scheduler",
         "name": "Thermostat Weekly Scheduler",
@@ -345,7 +345,7 @@
     },
     "domoticz-theme-manager": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Install and update themes via this theme manager",
         "folder": "domoticz-theme-manager",
         "name": "Domoticz Theme Manager ",
@@ -353,7 +353,7 @@
     },
     "WAN-IP-CHECKER": {
         "author": "ycahome",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Wan IP Checker",
         "folder": "WAN-IP-CHECKER",
         "name": "WAN-IP-CHECKER",
@@ -361,7 +361,7 @@
     },
     "YamahaPlug": {
         "author": "thomas-villagers",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Yamaha AV Receiver with Kodi Remote",
         "folder": "yamaha-av-receiver",
         "name": "Yamaha AV Receiver",
@@ -369,7 +369,7 @@
     },
     "Zigate": {
         "author": "zaraki673 & pipiche38",
-        "branch": "stable6",
+        "branch": ["stable6", "beta6", "development"],
         "description": "Allow Domoticz to access to the Zigbee worlds of devices",
         "folder": "Zigate",
         "name": "Zigbee for domoticz plugin",
@@ -377,7 +377,7 @@
     },
     "Zigbee2MQTT": {
         "author": "stas-demydiuk",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Domoticz integration with zigbee2mqtt project",
         "folder": "zigbee2mqtt",
         "name": "Zigbee2MQTT",
@@ -385,7 +385,7 @@
     },
     "deCONZ": {
         "author": "Smanar",
-        "branch": "master",
+        "branch": ["master"],
         "description": "deCONZ bridge (For Conbee,Raspbee)",
         "folder": "deCONZ",
         "name": "Domoticz-deCONZ",
@@ -393,7 +393,7 @@
     },
     "ebusd": {
         "author": "guillaumezin",
-        "branch": "master",
+        "branch": ["master"],
         "description": "ebusd bridge",
         "folder": "ebusd",
         "name": "DomoticzEbusd",
@@ -401,7 +401,7 @@
     },
     "ems-gateway": {
         "author": "bbqkees",
-        "branch": "master",
+        "branch": ["master"],
         "description": "EMS bus Wi-Fi Gateway",
         "folder": "ems-gateway",
         "name": "ems-esp-domoticz-plugin",
@@ -409,7 +409,7 @@
     },
     "eq3max": {
         "author": "mvzut",
-        "branch": "master",
+        "branch": ["master"],
         "description": "eQ-3 MAX! Cube",
         "folder": "eq3max",
         "name": "maxcube-Domoticz-plugin",
@@ -417,7 +417,7 @@
     },
     "ewpe-smart-mqtt": {
         "author": "stas-demydiuk",
-        "branch": "master",
+        "branch": ["master"],
         "description": "EwpeSmart (Gree, Cooper&Hunter, etc.) Air Conditioners control via MQTT",
         "folder": "ewpe-smart-mqtt",
         "name": "EwpeSmart Air Conditioners via MQTT",
@@ -425,7 +425,7 @@
     },
     "freeboxv6": {
         "author": "supermat",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Freebox V6 (Revolution)",
         "folder": "freeboxv6",
         "name": "PluginDomoticzFreebox",
@@ -433,7 +433,7 @@
     },
     "iDetect": {
         "author": "d-EScape",
-        "branch": "master",
+        "branch": ["master"],
         "description": "iDetect Presence Detection",
         "folder": "iDetect",
         "name": "Domoticz_iDetect",
@@ -441,7 +441,7 @@
     },
     "mikrotik-routeros": {
         "author": "mrin",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Mikrotik RouterOS",
         "folder": "mikrotik-routeros",
         "name": "domoticz-routeros-plugin",
@@ -449,7 +449,7 @@
     },
     "owrtwifi2domo": {
         "author": "enesbcs",
-        "branch": "master",
+        "branch": ["master"],
         "description": "OpenWRT Wifi Presence Detector to MQTT translator",
         "folder": "owrtwifi2domo",
         "name": "OpenWRT Wifi Presence MQTT",
@@ -457,7 +457,7 @@
     },
     "plugins-manager": {
         "author": "stas-demydiuk",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Allows to manage python plugins through custom UI page",
         "folder": "plugins-manager",
         "name": "Python Plugins Manager",
@@ -465,7 +465,7 @@
     },
     "pyrtl433": {
         "author": "enesbcs",
-        "branch": "master",
+        "branch": ["master"],
         "description": "RTL_433 MQTT receiver",
         "folder": "pyrtl433",
         "name": "RTL433 MQTT",
@@ -473,7 +473,7 @@
     },
     "sony": {
         "author": "gerard33",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Sony Bravia TV (with Kodi remote)",
         "folder": "sony",
         "name": "sony-bravia",
@@ -481,7 +481,7 @@
     },
     "WLANThermo": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "WLANThermo",
         "folder": "Domoticz-WLANThermo-Plugin",
         "name": "WLANThermo",
@@ -489,7 +489,7 @@
     },
     "WLED": {
         "author": "frustreermeneer",
-        "branch": "master",
+        "branch": ["master"],
         "description": "WLED",
         "folder": "wled",
         "name": "WLED Plugin",
@@ -497,7 +497,7 @@
     },
     "xiaomi-mi-robot-vacuum": {
         "author": "mrin",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Xiaomi Mi Robot Vacuum",
         "folder": "xiaomi-mirobot",
         "name": "Xiaomi Mi Robot Vacuum",
@@ -505,7 +505,7 @@
     },
     "yi-hack": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Yi Hack Plugin",
         "folder": "yi-hack",
         "name": "Yi Hack Plugin",
@@ -513,7 +513,7 @@
     },
     "Update_timer_Plugin": {
         "author": "skarab22",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Synchronize your devices on the corresponding active timer",
         "folder": "Update_timer",
         "name": "Update_timer Plugin",
@@ -521,7 +521,7 @@
     },
     "Tasmoticz": {
         "author": "joba-1",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Python plugin for autodetecting ESP8266 devices with Tasmota firmware in Domoticz Homeautomation.",
         "folder": "Tasmoticz",
         "name": "Tasmoticz",
@@ -529,7 +529,7 @@
     },
     "Tuya": {
         "author": "guino",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Controls TUYA devices your network (mainly on/off switches and Lights).",
         "folder": "tuyaha",
         "name": "Tuya",
@@ -537,7 +537,7 @@
     },
     "WuDirect": {
         "author": "vaneeten",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Direct reception and parsing of Wunderground-formatted Weatherstation data.",
         "folder": "domoticz-wudirect",
         "name": "WuDirect",
@@ -545,7 +545,7 @@
     },
     "Panasonic Cloud Comfort": {
         "author": "sdamasoc",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Panasonic Cloud Comfort plugin (originally CZ-TACG1 but works for all)",
         "folder": "domoticz_panasonic_CZ-TACG1",
         "name": "Panasonic Cloud Comfort",

--- a/plugins.json
+++ b/plugins.json
@@ -1,7 +1,7 @@
 {
     "AAPIPModule": {
         "author": "febalci",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Crow Runner Alarm",
         "folder": "AAPIPModule",
         "name": "DomoticzCrowAlarm",
@@ -9,7 +9,7 @@
     },
     "BatteryLevel": {
         "author": "999LV",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Battery monitoring for Z-Wave nodes",
         "folder": "BatteryLevel",
         "name": "BatteryLevel",
@@ -17,7 +17,7 @@
     },
     "Buienradar": {
         "author": "ffes",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Buienradar.nl (Weather lookup)",
         "folder": "Buienradar",
         "name": "domoticz-buienradar",
@@ -25,7 +25,7 @@
     },
     "ChromecastPlugin": {
         "author": "Tsjippy",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Chromecast plugin for Domoticz",
         "folder": "ChromecastPlugin",
         "name": "ChromecastPlugin",
@@ -33,7 +33,7 @@
 	},
     "CreasolDombusPlugin": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Creasol DomBus RS485 modules (I/Os and sensors)",
         "folder": "CreasolDomBus",
         "name": "CreasolDomBusPlugin",
@@ -41,7 +41,7 @@
     },
     "DDS238": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "DDS238 ZN/S energy meter, single phase, Modbus RTU",
         "folder": "domoticz-dds238",
         "name": "domoticz-dds238",
@@ -49,7 +49,7 @@
     },
     "DTS238": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "DTS238 ZN/S energy meter, three phase, Modbus RTU",
         "folder": "domoticz-dts238",
         "name": "domoticz-dts238",
@@ -57,7 +57,7 @@
     },
     "Denon4306": {
         "author": "dnpwwo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Denon/Marantz Amplifier",
         "folder": "Denon4306",
         "name": "Domoticz-Denon-Plugin",
@@ -65,7 +65,7 @@
     },
     "DysonPureLink": {
         "author": "JanJaapKo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Domoticz plugin to integrate the Dyson PureLink devices",
         "folder": "DysonPureLink",
         "name": "Dyson Pure Link",
@@ -73,7 +73,7 @@
     },
     "EmmetiEQ2021": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Emmeti EQ 2021 and EQ 3021 ES hot water heat pumps",
         "folder": "domoticz-emmeti-eq2021",
         "name": "Emmeti hot water heat pump",
@@ -81,7 +81,7 @@
     },
     "EmmetiMirai": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Emmeti Mirai heat pumps management",
         "folder": "domoticz-emmeti-mirai",
         "name": "Emmeti Mirai heat pump",
@@ -89,7 +89,7 @@
     },
     "GC-100": {
         "author": "dnpwwo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Global Cache 100",
         "folder": "GC-100",
         "name": "Domoticz-GlobalCache-Plugin",
@@ -97,7 +97,7 @@
     },
     "GoodWeAPI": {
         "author": "JanJaapKo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Provides information about your GoodWe solar inverter too Domoticz",
         "folder": "domoticz-GoodWeSEMS",
         "name": "GoodWE Solar inverter via SEMS API",
@@ -105,7 +105,7 @@
     },
     "GoveeDiscovery": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Plugin to discover Govee devices on the local network and create/update devices in Domoticz",
         "folder": "Domoticz-Govee-Plugin",
         "name": "Govee Local Api Control",
@@ -113,7 +113,7 @@
     },
     "Hisense-AEH-W4A1": {
         "author": "x-th-unicorn",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Domoticz Python plugin for Hisense AC (AEH-W4A1)",
         "folder": "domoticz-aeh-w4a1",
         "name": "domoticz-aeh-w4a1",
@@ -121,7 +121,7 @@
     },
     "HivePlug": {
         "author": "imcfarla2003",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Hive Plugin",
         "folder": "HivePlug",
         "name": "domoticz-hive",
@@ -129,7 +129,7 @@
     },
     "Homewizard": {
         "author": "rvdvoorde",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Homewizard",
         "folder": "Homewizard",
         "name": "domoticz-homewizard",
@@ -137,7 +137,7 @@
     },
     "HyundaiKia": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Hyundai and Kia connect cars",
         "folder": "domoticz-hyundai-kia",
         "name": "Hyundai and kia connect cars",
@@ -145,7 +145,7 @@
     },
     "IKEA-Tradfri": {
         "author": "moroen",
-        "branch": "master",
+        "branch": ["master"],
         "description": "IKEA Tradfri",
         "folder": "IKEA-Tradfri",
         "name": "IKEA-Tradfri-plugin",
@@ -153,7 +153,7 @@
     },
     "IthoWifi": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Itho Wifi module",
         "folder": "Domoticz-Itho-Wifi-Plugin",
         "name": "Domoticz-Itho-Wifi-Plugin",
@@ -161,7 +161,7 @@
     },
 	"KiaUVOHyundaiBlueLink": {
 		"author": "CreasolTech",
-		"branch": "master",
+		"branch": ["master"],
 		"description": "Kia UVO and Hyundai BlueLink vehicles",
 		"folder": "domoticz-kia-hyundai",
 		"name": "Kia UVO and Hyundai BlueLink vehicles plugin",
@@ -169,7 +169,7 @@
 	},
      "Kodi": {
         "author": "dnpwwo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Kodi Media Player Plugin",
         "folder": "Domoticz-Kodi-Plugin",
         "name": "Kodi Players",
@@ -177,7 +177,7 @@
     },
     "Life360": {
         "author": "febalci",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Life 360 Presence",
         "folder": "Life360",
         "name": "DomoticzLife360",
@@ -185,7 +185,7 @@
     },
     "Linky": {
         "author": "guillaumezin",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Linky",
         "folder": "Linky",
         "name": "DomoticzLinky",
@@ -193,7 +193,7 @@
     },
     "MQTTDiscovery": {
         "author": "emontnemery",
-        "branch": "development",
+        "branch": ["development"],
         "description": "MQTT discovery",
         "folder": "MQTTDiscovery",
         "name": "domoticz_mqtt_discovery",
@@ -201,7 +201,7 @@
     },
     "MeteoAlarmEU": {
         "author": "ycahome",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Meteo Alarm EU RSS Reader",
         "folder": "MeteoAlarmEU",
         "name": "MeteoAlarmEU",
@@ -209,7 +209,7 @@
     },
     "Mi_Flower_mate": {
         "author": "flatsiedatsie",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Xiaomi Mi Flower Mate",
         "folder": "Mi_Flower_mate_plugin",
         "name": "Xiaomi Mi Flower Mate",
@@ -217,7 +217,7 @@
     },
     "MilightESP8266": {
         "author": "mrin",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Support for ESP8266 Milight hub",
         "folder": "espmilighthub-domoticz",
         "name": "ESP8266 Milight Hub",
@@ -225,7 +225,7 @@
     },
     "MoonPhases": {
         "author": "ycahome",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Moon Phases",
         "folder": "MoonPhases",
         "name": "MoonPhases",
@@ -233,7 +233,7 @@
     },
     "NUT_UPS": {
         "author": "999LV",
-        "branch": "master",
+        "branch": ["master"],
         "description": "UPS Monitor python plugin for Domoticz",
         "folder": "NUT_UPS",
         "name": "UPS Monitor",
@@ -241,7 +241,7 @@
     },
     "Onkyo": {
         "author": "jorgh6",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Onkyo AV Receiver",
         "folder": "Onkyo",
         "name": "domoticz-onkyo-plugin",
@@ -249,7 +249,7 @@
     },
     "PioneerAVR": {
         "author": "febalci",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Pioneer AVR",
         "folder": "PioneerAVR",
         "name": "DomoticzPioneerAVR",
@@ -257,7 +257,7 @@
     },
     "PZEM-016": {
         "author": "CreasolTech",
-        "branch": "master",
+        "branch": ["master"],
         "description": "PZEM-016 PZEM-014 and PZEM-004T energy meters (supports up to 51 meters on the same bus)",
         "folder": "domoticz-pzem-016",
         "name": "PZEM-016 PZEM-014 PZEM-004T energy meters",
@@ -265,7 +265,7 @@
     },
     "Quatt": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Quatt",
         "folder": "Domoticz-Quatt-Plugin",
         "name": "Domoticz-Quatt-Plugin",
@@ -273,7 +273,7 @@
     },
     "RAVEn": {
         "author": "dnpwwo",
-        "branch": "master",
+        "branch": ["master"],
         "description": "RAVEn Zigbee energy monitor",
         "folder": "RAVEn",
         "name": "Domoticz-RAVEn-Plugin",
@@ -281,7 +281,7 @@
     },
     "SNMPreader": {
         "author": "ycahome",
-        "branch": "master",
+        "branch": ["master"],
         "description": "SNMP Reader",
         "folder": "SNMPreader",
         "name": "SNMPreader",
@@ -289,7 +289,7 @@
     },
     "SYSFS-Switches": {
         "author": "flatsiedatsie",
-        "branch": "master",
+        "branch": ["master"],
         "description": "SYSFS-Switches",
         "folder": "SYSFS-Switches",
         "name": "GPIO-SYSFS-Switches",
@@ -297,7 +297,7 @@
     },
     "SeismicPortal": {
         "author": "febalci",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Eartquake EMSC Data",
         "folder": "SeismicPortal",
         "name": "DomoticzEarthquake",
@@ -305,7 +305,7 @@
     },
     "Shelly_MQTT": {
         "author": "enesbcs",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Shelly MQTT translator",
         "folder": "Shelly_MQTT",
         "name": "Shelly MQTT",
@@ -313,7 +313,7 @@
     },
     "SmogTok": {
         "author": "smogtok",
-        "branch": "master",
+        "branch": ["master"],
         "description": "SmogTok Air Quality monitor",
         "folder": "SmogTok",
         "name": "smogtokdomoticzplug",
@@ -321,7 +321,7 @@
     },
     "solaredge modbus_tcp": {
         "author": "addiejansen",
-        "branch": "master",
+        "branch": ["master"],
         "description": "collect data from SolarEdge power inverters over ModbusTCP.",
         "folder": "domoticz-solaredge-modbustcp-plugin",
         "name": "solaredge modbus-tcp",
@@ -329,7 +329,7 @@
     },
     "Sonos": {
         "author": "gerard33",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Sonos Players",
         "folder": "Sonos",
         "name": "sonos",
@@ -337,7 +337,7 @@
     },
     "Synology SurveillanceStation": {
         "author": "lolautruche",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Synology SurveillanceStation",
         "folder": "Synology SurveillanceStation",
         "name": "SurveillanceStationDomoticz",
@@ -345,7 +345,7 @@
     },
     "TasmotaH801": {
         "author": "stas-demydiuk",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Control H801 LED WiFi Controller with Tasmota firmware via MQTT",
         "folder": "h801-tasmota-plugin",
         "name": "H801 LED WiFi Controller with Tasmota firmware",
@@ -353,7 +353,7 @@
     },
     "Thermostat Weekly Scheduler": {
         "author": "ArtBern",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Manipulate schedule for virtual thermostat on weekly basis. Easy switch for timer plans.",
         "folder": "thermostat-weekly-scheduler",
         "name": "Thermostat Weekly Scheduler",
@@ -361,7 +361,7 @@
     },
     "domoticz-theme-manager": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Install and update themes via this theme manager",
         "folder": "domoticz-theme-manager",
         "name": "Domoticz Theme Manager ",
@@ -369,7 +369,7 @@
     },
     "WAN-IP-CHECKER": {
         "author": "ycahome",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Wan IP Checker",
         "folder": "WAN-IP-CHECKER",
         "name": "WAN-IP-CHECKER",
@@ -377,7 +377,7 @@
     },
     "XiaomiPM": {
         "author": "febalci",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Xiaomi PM2.5 Sensor",
         "folder": "XiaomiPM",
         "name": "Xiaomi PM2.5 Sensor",
@@ -385,7 +385,7 @@
     },
     "YamahaPlug": {
         "author": "thomas-villagers",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Yamaha AV Receiver with Kodi Remote",
         "folder": "yamaha-av-receiver",
         "name": "Yamaha AV Receiver",
@@ -393,7 +393,7 @@
     },
     "Zigate": {
         "author": "zaraki673 & pipiche38",
-        "branch": "stable6",
+        "branch": ["stable6", "beta6", "development"],
         "description": "Allow Domoticz to access to the Zigbee worlds of devices",
         "folder": "Zigate",
         "name": "Zigbee for domoticz plugin",
@@ -401,7 +401,7 @@
     },
     "Zigbee2MQTT": {
         "author": "stas-demydiuk",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Domoticz integration with zigbee2mqtt project",
         "folder": "zigbee2mqtt",
         "name": "Zigbee2MQTT",
@@ -409,7 +409,7 @@
     },
     "deCONZ": {
         "author": "Smanar",
-        "branch": "master",
+        "branch": ["master"],
         "description": "deCONZ bridge (For Conbee,Raspbee)",
         "folder": "deCONZ",
         "name": "Domoticz-deCONZ",
@@ -417,7 +417,7 @@
     },
     "ebusd": {
         "author": "guillaumezin",
-        "branch": "master",
+        "branch": ["master"],
         "description": "ebusd bridge",
         "folder": "ebusd",
         "name": "DomoticzEbusd",
@@ -425,7 +425,7 @@
     },
     "ems-gateway": {
         "author": "bbqkees",
-        "branch": "master",
+        "branch": ["master"],
         "description": "EMS bus Wi-Fi Gateway",
         "folder": "ems-gateway",
         "name": "ems-esp-domoticz-plugin",
@@ -433,7 +433,7 @@
     },
     "eq3max": {
         "author": "mvzut",
-        "branch": "master",
+        "branch": ["master"],
         "description": "eQ-3 MAX! Cube",
         "folder": "eq3max",
         "name": "maxcube-Domoticz-plugin",
@@ -441,7 +441,7 @@
     },
     "ewpe-smart-mqtt": {
         "author": "stas-demydiuk",
-        "branch": "master",
+        "branch": ["master"],
         "description": "EwpeSmart (Gree, Cooper&Hunter, etc.) Air Conditioners control via MQTT",
         "folder": "ewpe-smart-mqtt",
         "name": "EwpeSmart Air Conditioners via MQTT",
@@ -449,7 +449,7 @@
     },
     "freeboxv6": {
         "author": "supermat",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Freebox V6 (Revolution)",
         "folder": "freeboxv6",
         "name": "PluginDomoticzFreebox",
@@ -457,7 +457,7 @@
     },
     "iDetect": {
         "author": "d-EScape",
-        "branch": "master",
+        "branch": ["master"],
         "description": "iDetect Presence Detection",
         "folder": "iDetect",
         "name": "Domoticz_iDetect",
@@ -465,7 +465,7 @@
     },
     "mikrotik-routeros": {
         "author": "mrin",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Mikrotik RouterOS",
         "folder": "mikrotik-routeros",
         "name": "domoticz-routeros-plugin",
@@ -473,7 +473,7 @@
     },
     "owrtwifi2domo": {
         "author": "enesbcs",
-        "branch": "master",
+        "branch": ["master"],
         "description": "OpenWRT Wifi Presence Detector to MQTT translator",
         "folder": "owrtwifi2domo",
         "name": "OpenWRT Wifi Presence MQTT",
@@ -481,7 +481,7 @@
     },
     "plugins-manager": {
         "author": "stas-demydiuk",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Allows to manage python plugins through custom UI page",
         "folder": "plugins-manager",
         "name": "Python Plugins Manager",
@@ -489,7 +489,7 @@
     },
     "pyrtl433": {
         "author": "enesbcs",
-        "branch": "master",
+        "branch": ["master"],
         "description": "RTL_433 MQTT receiver",
         "folder": "pyrtl433",
         "name": "RTL433 MQTT",
@@ -497,7 +497,7 @@
     },
     "sony": {
         "author": "gerard33",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Sony Bravia TV (with Kodi remote)",
         "folder": "sony",
         "name": "sony-bravia",
@@ -505,7 +505,7 @@
     },
     "xfr-pimonitor": {
         "author": "Xorfor",
-        "branch": "master",
+        "branch": ["master"],
         "description": "PiMonitor",
         "folder": "xfr-pimonitor",
         "name": "Domoticz-PiMonitor-Plugin",
@@ -513,7 +513,7 @@
     },
     "xfr_aardbeving": {
         "author": "Xorfor",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Dutch earthquakes",
         "folder": "xfr_aardbeving",
         "name": "Domoticz-LastDutchEarthquake-Plugin",
@@ -521,7 +521,7 @@
     },
     "xfr_discusage": {
         "author": "Xorfor",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Disc usage",
         "folder": "xfr_discusage",
         "name": "Domoticz-Disc-usage-Plugin",
@@ -529,7 +529,7 @@
     },
     "xfr_openaq": {
         "author": "Xorfor",
-        "branch": "master",
+        "branch": ["master"],
         "description": "OpenAQ",
         "folder": "xfr_openaq",
         "name": "Domoticz-OpenAQ-Plugin",
@@ -537,7 +537,7 @@
     },
     "xfr_pihole": {
         "author": "Xorfor",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Pi-hole summary",
         "folder": "xfr_pihole",
         "name": "Domoticz-Pi-hole-Plugin",
@@ -545,7 +545,7 @@
     },
     "xfr_speedtest": {
         "author": "Xorfor",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Speedtest",
         "folder": "xfr_speedtest",
         "name": "Domoticz-Speedtest-Plugin",
@@ -553,7 +553,7 @@
     },
     "WLANThermo": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "WLANThermo",
         "folder": "Domoticz-WLANThermo-Plugin",
         "name": "WLANThermo",
@@ -561,7 +561,7 @@
     },
     "WLED": {
         "author": "frustreermeneer",
-        "branch": "master",
+        "branch": ["master"],
         "description": "WLED",
         "folder": "wled",
         "name": "WLED Plugin",
@@ -569,7 +569,7 @@
     },
     "xiaomi-mi-robot-vacuum": {
         "author": "mrin",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Xiaomi Mi Robot Vacuum",
         "folder": "xiaomi-mirobot",
         "name": "Xiaomi Mi Robot Vacuum",
@@ -577,7 +577,7 @@
     },
     "yi-hack": {
         "author": "galadril",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Yi Hack Plugin",
         "folder": "yi-hack",
         "name": "Yi Hack Plugin",
@@ -585,7 +585,7 @@
     },
     "Update_timer_Plugin": {
         "author": "skarab22",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Synchronize your devices on the corresponding active timer",
         "folder": "Update_timer",
         "name": "Update_timer Plugin",
@@ -593,7 +593,7 @@
     },
     "Tasmoticz": {
         "author": "joba-1",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Python plugin for autodetecting ESP8266 devices with Tasmota firmware in Domoticz Homeautomation.",
         "folder": "Tasmoticz",
         "name": "Tasmoticz",
@@ -601,7 +601,7 @@
     },
     "Tuya": {
         "author": "guino",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Controls TUYA devices your network (mainly on/off switches and Lights).",
         "folder": "tuyaha",
         "name": "Tuya",
@@ -609,7 +609,7 @@
     },
     "WuDirect": {
         "author": "vaneeten",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Direct reception and parsing of Wunderground-formatted Weatherstation data.",
         "folder": "domoticz-wudirect",
         "name": "WuDirect",
@@ -617,7 +617,7 @@
     },
     "Panasonic Cloud Comfort": {
         "author": "sdamasoc",
-        "branch": "master",
+        "branch": ["master"],
         "description": "Panasonic Cloud Comfort plugin (originally CZ-TACG1 but works for all)",
         "folder": "domoticz_panasonic_CZ-TACG1",
         "name": "Panasonic Cloud Comfort",

--- a/plugins.json
+++ b/plugins.json
@@ -1,7 +1,7 @@
 {
     "AAPIPModule": {
         "author": "febalci",
-        "branch": [["master"]],
+        "branch": ["master"],
         "description": "Crow Runner Alarm",
         "folder": "AAPIPModule",
         "name": "DomoticzCrowAlarm",
@@ -9,7 +9,7 @@
     },
     "AWTRIX3": {
         "author": "galadril",
-        "branch": [["master"]],
+        "branch": ["master"],
         "description": "AWTRIX3 Smart Clock",
         "folder": "Domoticz-AWTRIX3-Plugin",
         "name": "AWTRIX3",


### PR DESCRIPTION
Fixes #23

Update `plugins.json` to allow specifying multiple branches for each plugin.

* Change the `branch` field to a list of branches for each plugin.
* Update the `Zigate` plugin entry to include multiple branches: "stable6", "beta6", and "development".
* Modify all other plugin entries to have their `branch` field as a list containing "master". 

